### PR TITLE
修正部分APK读取的ICON数据时UNICODE编码时报错的问题

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -111,7 +111,7 @@ function findApkInfoIcon (info) {
       resultMap['applicataion-icon-120'] = maxDpiIcon.icon
     }
 
-    return maxDpiIcon.icon
+    return maxDpiIcon.icon.split('\u0000').join('')
   } else {
     throw new Error('Unexpected icon type: ', info.application.icon)
   }


### PR DESCRIPTION
去掉包含的空白编码字符