### PR TITLE
Fix some parse error

### DIFF
--- a/lib/apk.js
+++ b/lib/apk.js
@@ -32,8 +32,12 @@ class ApkParser extends Zip {
       // 结合resourcemap再次解析apkInfo
       apkInfo = mapInfoResource(apkInfo, resourceMap)
       // 获取icon base64值
-      const iconBuffer = await this.getEntry(findApkInfoIcon(apkInfo))
-      apkInfo.icon = getBase64FromBuffer(iconBuffer)
+      try {
+        const iconBuffer = await this.getEntry(findApkInfoIcon(apkInfo))
+        apkInfo.icon = getBase64FromBuffer(iconBuffer)
+      } catch (err) {
+        apkInfo.icon = null
+      }
 
       return apkInfo
     } catch (e) {

--- a/lib/apk.js
+++ b/lib/apk.js
@@ -22,7 +22,13 @@ class ApkParser extends Zip {
       // 解析 manifest
       let apkInfo = this._parseManifest(buffers[ManifestName])
       // 解析 resourcemap
-      const resourceMap = this._parseresourceMap(buffers[ResourceName])
+      let resourceMap
+      if (!buffers[ResourceName]) {
+        resourceMap = {}
+      } else {
+        // 解析 resourcemap
+        resourceMap = this._parseresourceMap(buffers[ResourceName])
+      }
       // 结合resourcemap再次解析apkInfo
       apkInfo = mapInfoResource(apkInfo, resourceMap)
       // 获取icon base64值


### PR DESCRIPTION
Some apks has no resources.asrc, which may cause error, here is a sample:

[KwCrack.apk.zip](https://github.com/chenquincy/app-info-parser/files/3185076/KwCrack.apk.zip)