### PR TITLE
Keep printable characters for version name

### DIFF
--- a/lib/xml-parser/binary.js
+++ b/lib/xml-parser/binary.js
@@ -545,7 +545,9 @@ and is supposed to end at offset ${end}. Ignoring the rest of the value.`)
     if (valueRef > 0) {
       // some apk have versionName with special characters
       if (attr.name === 'versionName') {
-        this.strings[valueRef] = this.strings[valueRef].replace(/[^\d\w-.]/g, '')
+        // only keep printable characters
+        // https://www.ascii-code.com/characters/printable-characters
+        this.strings[valueRef] = this.strings[valueRef].replace(/[^\x21-\x7E]/g, '')
       }
       attr.value = this.strings[valueRef]
     }


### PR DESCRIPTION
The current logic would truncate version name like `1.0.2(1)` to `1.0.21`.
Try to raise the limit to all printable characters from https://www.ascii-code.com/characters/printable-characters